### PR TITLE
Add symlink entries to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,8 @@
 # Use `binary` to make sure certain files are never auto-detected as text.
 #
 #*.png binary
+
+libmp-units/src/core symlink=dir
+libmp-units/src/systems symlink=dir
+libmp-units-tests/libmp-units-tests/runtime symlink=dir
+libmp-units-tests/libmp-units-tests/static symlink=dir


### PR DESCRIPTION
Directory symlink annotations need to be added to `build2` packages for correct checkout behaviour (I think this may be a windows specific issue, but it's generally done for all packages).